### PR TITLE
Fixes to Node Class matching

### DIFF
--- a/nk_parser/nuke_parser/parser.py
+++ b/nk_parser/nuke_parser/parser.py
@@ -309,12 +309,15 @@ class Node:
             All child nodes if no filter was used, else only nodes that match classes in filters.
 
         """
+        if not filters:
+            return tuple(self._allNodes())
+        if isinstance(filters, str):
+            filters = (filters,)
         return tuple(
-            [
-                node
-                for node in self._allNodes()
-                if not filters or node.Class() in filters
-            ]
+            node
+            for node_class in filters
+            for node in self._allNodes()
+            if node.Class() == node_class
         )
 
     def path(self) -> str:


### PR DESCRIPTION
Fixed issue where multiple Node Classes would match if the requested Node Class name was "in" another Node Class. Example: "Read" would grab all "Read", "DeepRead", "ReadGeo" etc.