### PR TITLE
skip line that seems to be a long binary line.

### DIFF
--- a/nk_parser/nuke_parser/parser.py
+++ b/nk_parser/nuke_parser/parser.py
@@ -35,6 +35,7 @@ _PUSH_RE = re.compile(r"push \$(?P<key>\w+)")
 _VERSION_RE = re.compile(r"version[ ]+(?P<version>[\d\.]+([ ]v\d)?)")
 _CLONE_RE = re.compile(r"clone \$(?P<key>\w+)\s\{")
 _NODE_KNOB_RE = re.compile(r"^\s*(?P<key>[\w_\.]+)[ ]+(?P<value>(:?\"|\w|\{|-|/).*)")
+_BINARY_RE = re.compile(r"[0-9a-fA-F;]{100,}")
 
 
 _GROUP_NODE_CLASSES = ("Group", "Gizmo", "VariableGroup")
@@ -497,6 +498,13 @@ def _parseNk(file_path: str, gizmos: Optional[dict] = None) -> Node:
         if "push 0" in line:
             main_stack.push(None)
             continue
+
+        elif _BINARY_RE.search(line):
+            # Some lines contain extremely long character sequences, making regex processing very slow
+            # (e.g., knob render options from Nuke OpticalFlares).
+            # These lines are skipped since they are not needed for graph creation.
+            continue
+
         elif _BRANCH_STACK_RE.search(line):  # set stack-key
             key = _BRANCH_STACK_RE.search(line).group("key")
             if key in "cut_paste_input":


### PR DESCRIPTION
Hello,

Thanks for your tool, its great !

We created this PR because we ran into a performance issue encountered when parsing certain nodes from third-party plugins, such as Optical Flares.
They store extremely large strings that seems to be a precompiled hex, and running regex operations on these values significantly impacts performance.

Since these particular fields are not required for recreating the node graph, this PR proposes skipping them during parsing. (made by @Rogouan )

Here is an exemple of its data (I cropped the string for convinience) : 

```
OpticalFlares {
 renderOptions "117599;4f465003b80b01000032000400180000003300040006000000340020000000000000000000000000000000000000000000000000000000000000000000d00701000032000400700000003300040000000000340020000000c84200000000000000000000000000000000000000000000000000000000d007010000320004"
 name OpticalFlares1
 xpos 4405
 ypos 11095
}
```

Thanks !
